### PR TITLE
Create basic schema

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
 API_PORT=3000
-DATABASE_URL_PRODUCTION=postgresql://username:password@localhost/truthgoggles
-DATABASE_URL_DEVELOPMENT=postgresql://username:password@localhost/truthgoggles_dev
-DATABASE_URL_TEST=postgresql://username:password@localhost/truthgoggles_test
+DATABASE_URL_PRODUCTION=postgresql://username:password@localhost/tpt
+DATABASE_URL_DEVELOPMENT=postgresql://username:password@localhost/tpt_dev
+DATABASE_URL_TEST=postgresql://username:password@localhost/tpt_test

--- a/README.md
+++ b/README.md
@@ -30,12 +30,20 @@ mv distributions.obj nlp/truecaser_distributions.obj
 rm english_distributions.obj.zip
 ```
 
+Create the database:
+
+```
+createdb tpt
+createuser tpt -P
+```
+
 Setting up this project:
 
 ```
-$> yarn install
-$> cp .env.template .env && vi .env
-$> yarn start
+yarn install
+cp .env.template .env && vi .env
+sequelize db:migrate
+yarn start
 ```
 
 After you finish these steps, it probably won't actually work, but this is better than no documentation, right?

--- a/src/client/public/index.html
+++ b/src/client/public/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/dt-1.10.18/datatables.min.css"/>
+  <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/dt-1.10.18/datatables.min.js"></script>
+  <title>Talking Point Tracker</title>
+  <script type="text/javascript">
+
+    $(function() {
+      var mainTable = $("#mainTable").DataTable({});
+      $.ajax({
+        type: "GET",
+        url: "/graphql?query=query AllContent { namedEntities { sentenceId, entity, type } } ",
+        success: function(response) {
+          var dict = {};
+          for(var x in response.data.namedEntities) {
+            var item = response.data.namedEntities[x];
+            if(!dict[item.entity]) {
+              dict[item.entity] = 0
+            }
+            dict[item.entity] += 1;
+          }
+          $table = $("#entities").DataTable({
+            pageLength: 100,
+            order: [[ 1, "desc" ]]
+          });
+
+          for(var x in dict) {
+            var row = [
+              x,
+              dict[x],
+            ];
+            $table.row.add(row).draw(false);
+          }
+        }
+      });
+    });
+
+  </script>
+</head>
+<body>
+  <h1>Named Entities on CSPAN</h1>
+  <table id="entities">
+    <thead>
+      <tr>
+        <th style="width: 200px;">Entity</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</body>
+</html>

--- a/src/client/public/sentences.html
+++ b/src/client/public/sentences.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/dt-1.10.18/datatables.min.css"/>
+  <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/dt-1.10.18/datatables.min.js"></script>
+  <title>Talking Point Tracker</title>
+  <script type="text/javascript">
+
+    $(function() {
+      var mainTable = $("#mainTable").DataTable({});
+      $.ajax({
+        type: "GET",
+        url: "/graphql?query=query AllContent { sentences { content } } ",
+        success: function(response) {
+          $table = $("#sentences").DataTable({
+            pageLength: 100
+          });
+
+          for(var x in response.data.sentences) {
+            var item = response.data.sentences[x];
+            var row = [
+              "",
+              item.content
+            ]
+            $table.row.add(row).draw(false);
+          }
+        }
+      });
+    });
+
+  </script>
+</head>
+<body>
+  <h1>Sentences on CSPAN</h1>
+  <table id="sentences" style="width:100%;">
+    <thead>
+      <tr>
+        <th style="width: 200px;"></th>
+        <th style="width: 100%;"></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</body>
+</html>

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,9 +2,11 @@ import http from 'http'
 import express from 'express'
 import dotenv from 'dotenv'
 import graphqlHTTP from 'express-graphql'
+import path from 'path'
+
 import schema from './schema'
 
-import openedCaptionsWorker from './workers/opened-captions'
+import openedCaptionsWorker from './workers/openedCaptions'
 
 // Configure settings
 dotenv.config()
@@ -13,6 +15,10 @@ const port = process.env.API_PORT || 3000
 // Express app setup
 const app = express()
 const server = http.createServer(app)
+
+// Serve the static / compiled content
+app.use('/static', express.static(path.join(__dirname, '../client/public')))
+
 
 // GraphQL setup
 app.use('/graphql', graphqlHTTP({

--- a/src/server/migrations/20181101190050-create-channels-table.js
+++ b/src/server/migrations/20181101190050-create-channels-table.js
@@ -1,0 +1,29 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('channels', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    name: {
+      type: Sequelize.STRING,
+    },
+    call_sign: {
+      type: Sequelize.STRING,
+    },
+    stream_id: {
+      type: Sequelize.STRING,
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+
+  down: queryInterface => queryInterface.dropTable('channels'),
+};

--- a/src/server/migrations/20181101190103-create-sentences-table.js
+++ b/src/server/migrations/20181101190103-create-sentences-table.js
@@ -1,0 +1,30 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('sentences', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    content: {
+      type: Sequelize.TEXT,
+    },
+    channel_id: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'channels',
+        key: 'id'
+      },
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+
+  down: queryInterface => queryInterface.dropTable('sentences'),
+};

--- a/src/server/migrations/20181101190108-create-named-entities.js
+++ b/src/server/migrations/20181101190108-create-named-entities.js
@@ -1,0 +1,36 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('named_entities', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    entity: {
+      type: Sequelize.STRING,
+    },
+    type: {
+      type: Sequelize.STRING,
+    },
+    model: {
+      type: Sequelize.STRING,
+    },
+    sentence_id: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'sentences',
+        key: 'id'
+      },
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+
+  down: queryInterface => queryInterface.dropTable('named_entities'),
+};

--- a/src/server/models/channel.js
+++ b/src/server/models/channel.js
@@ -1,0 +1,34 @@
+module.exports = (sequelize, DataTypes) => {
+  const Channel = sequelize.define('Channel', {
+    base_url: {
+      type: DataTypes.STRING
+    },
+    name: {
+      type: DataTypes.STRING,
+    },
+    callSign: {
+      type: DataTypes.STRING,
+      field: 'call_sign',
+    },
+    streamId: {
+      type: DataTypes.STRING,
+      field: 'stream_id',
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'created_at',
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'updated_at',
+    },
+  }, {
+    tableName: 'channels',
+  })
+
+  Channel.associate = function () {}
+
+  return Channel
+}

--- a/src/server/models/namedEntity.js
+++ b/src/server/models/namedEntity.js
@@ -1,0 +1,37 @@
+module.exports = (sequelize, DataTypes) => {
+  const NamedEntity = sequelize.define('NamedEntity', {
+    entity: {
+      type: DataTypes.STRING,
+    },
+    type: {
+      type: DataTypes.STRING,
+    },
+    model: {
+      type: DataTypes.STRING,
+    },
+    sentenceId: {
+      type: DataTypes.INTEGER,
+      field: 'sentence_id',
+      references: {
+        model: 'sentence',
+        key: 'id'
+      },
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'created_at',
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'updated_at',
+    },
+  }, {
+    tableName: 'named_entities',
+  })
+
+  NamedEntity.associate = function () {}
+
+  return NamedEntity
+}

--- a/src/server/models/sentence.js
+++ b/src/server/models/sentence.js
@@ -1,0 +1,31 @@
+module.exports = (sequelize, DataTypes) => {
+  const Sentence = sequelize.define('Sentence', {
+    content: {
+      type: DataTypes.TEXT,
+    },
+    channelId: {
+      type: DataTypes.INTEGER,
+      field: 'channel_id',
+      references: {
+        model: 'channel',
+        key: 'id'
+      },
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'created_at',
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      field: 'updated_at',
+    },
+  }, {
+    tableName: 'sentences',
+  })
+
+  Sentence.associate = function () {}
+
+  return Sentence
+}

--- a/src/server/schema/mutation.js
+++ b/src/server/schema/mutation.js
@@ -1,11 +1,17 @@
 import { GraphQLObjectType } from 'graphql'
 
+// App Imports
+import * as namedEntity from './namedEntities/fields/mutations'
+import * as sentence from './sentences/fields/mutations'
+
 // Compile into a single export
 const mutation = new GraphQLObjectType({
   name: 'mutations',
   description: '...',
 
   fields: {
+    ...namedEntity,
+    ...sentence,
   },
 })
 

--- a/src/server/schema/namedEntities/fields/mutations.js
+++ b/src/server/schema/namedEntities/fields/mutations.js
@@ -1,0 +1,39 @@
+import { GraphQLString, GraphQLInt } from 'graphql'
+
+// App Imports
+import NamedEntityType from '../type'
+import { create, remove } from '../resolvers'
+
+export const namedEntityCreate = {
+  type: NamedEntityType,
+  args: {
+    entity: {
+      name: 'entity',
+      type: GraphQLString,
+    },
+    type: {
+      name: 'type',
+      type: GraphQLString,
+    },
+    model: {
+      name: 'model',
+      type: GraphQLString,
+    },
+    sentenceId: {
+      name: 'sentenceId',
+      type: GraphQLInt
+    },
+  },
+  resolve: create,
+}
+
+export const namedEntityRemove = {
+  type: NamedEntityType,
+  args: {
+    id: {
+      name: 'id',
+      type: GraphQLInt,
+    },
+  },
+  resolve: remove,
+}

--- a/src/server/schema/namedEntities/fields/query.js
+++ b/src/server/schema/namedEntities/fields/query.js
@@ -1,0 +1,18 @@
+import { GraphQLString, GraphQLInt, GraphQLList } from 'graphql'
+
+// App Imports
+import NamedEntityType from '../type'
+import { getAll, getById } from '../resolvers'
+
+export const namedEntities = {
+  type: new GraphQLList(NamedEntityType),
+  resolve: getAll,
+}
+
+export const namedEntity = {
+  type: NamedEntityType,
+  args: {
+    id: { type: GraphQLInt },
+  },
+  resolve: getById,
+}

--- a/src/server/schema/namedEntities/resolvers.js
+++ b/src/server/schema/namedEntities/resolvers.js
@@ -1,0 +1,31 @@
+import models from '../../models'
+
+// Get named entity by ID
+export async function getById(parentValue, { id }) {
+  return models.NamedEntity.findOne({ where: { id } })
+}
+
+// Get all named entities
+export async function getAll(parentValue, { }) {
+  return models.NamedEntity.findAll()
+}
+
+// Create named entity
+export async function create(parentValue, {
+  entity,
+  type,
+  model,
+  sentence_id,
+}) {
+  return models.CredibleContent.create({
+    entity,
+    type,
+    model,
+    sentence_id,
+  })
+}
+
+// Delete named entity
+export async function remove(parentValue, { id }) {
+  return models.NamedEntity.destroy({ where: { id } })
+}

--- a/src/server/schema/namedEntities/type.js
+++ b/src/server/schema/namedEntities/type.js
@@ -1,0 +1,18 @@
+import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql'
+
+const NamedEntityType = new GraphQLObjectType({
+  name: 'namedEntity',
+  description: 'A named entity that was mentioned on TV',
+
+  fields: () => ({
+    id: { type: GraphQLInt },
+    entity: { type: GraphQLString },
+    type: { type: GraphQLString },
+    model: { type: GraphQLString },
+    sentenceId: { type: GraphQLInt },
+    createdAt: { type: GraphQLString },
+    updatedAt: { type: GraphQLString },
+  }),
+})
+
+export default NamedEntityType

--- a/src/server/schema/query.js
+++ b/src/server/schema/query.js
@@ -1,11 +1,17 @@
 import { GraphQLObjectType } from 'graphql'
 
+// App Imports
+import * as namedEntity from './namedEntities/fields/query'
+import * as sentence from './sentences/fields/query'
+
 // Compile into a single export
 const query = new GraphQLObjectType({
   name: 'query',
   description: '...',
 
   fields: {
+    ...namedEntity,
+    ...sentence,
   },
 })
 

--- a/src/server/schema/sentences/fields/mutations.js
+++ b/src/server/schema/sentences/fields/mutations.js
@@ -1,0 +1,31 @@
+import { GraphQLString, GraphQLInt } from 'graphql'
+
+// App Imports
+import SentenceType from '../type'
+import { create, remove } from '../resolvers'
+
+export const sentenceCreate = {
+  type: SentenceType,
+  args: {
+    content: {
+      name: 'content',
+      type: GraphQLString,
+    },
+    channelId: {
+      name: 'channelId',
+      type: GraphQLInt
+    },
+  },
+  resolve: create,
+}
+
+export const sentenceRemove = {
+  type: SentenceType,
+  args: {
+    id: {
+      name: 'id',
+      type: GraphQLInt,
+    },
+  },
+  resolve: remove,
+}

--- a/src/server/schema/sentences/fields/query.js
+++ b/src/server/schema/sentences/fields/query.js
@@ -1,0 +1,18 @@
+import { GraphQLString, GraphQLInt, GraphQLList } from 'graphql'
+
+// App Imports
+import SentenceType from '../type'
+import { getAll, getById } from '../resolvers'
+
+export const sentences = {
+  type: new GraphQLList(SentenceType),
+  resolve: getAll,
+}
+
+export const sentence = {
+  type: SentenceType,
+  args: {
+    id: { type: GraphQLInt },
+  },
+  resolve: getById,
+}

--- a/src/server/schema/sentences/resolvers.js
+++ b/src/server/schema/sentences/resolvers.js
@@ -1,0 +1,27 @@
+import models from '../../models'
+
+// Get by ID
+export async function getById(parentValue, { id }) {
+  return models.Sentence.findOne({ where: { id } })
+}
+
+// Get all
+export async function getAll(parentValue, { }) {
+  return models.Sentence.findAll()
+}
+
+// Create
+export async function create(parentValue, {
+  content,
+  sentence_id,
+}) {
+  return models.Sentence.create({
+    content,
+    channel_id,
+  })
+}
+
+// Delete
+export async function remove(parentValue, { id }) {
+  return models.Sentence.destroy({ where: { id } })
+}

--- a/src/server/schema/sentences/type.js
+++ b/src/server/schema/sentences/type.js
@@ -1,0 +1,16 @@
+import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql'
+
+const SentenceType = new GraphQLObjectType({
+  name: 'sentence',
+  description: 'A sentence that was aired on TV',
+
+  fields: () => ({
+    id: { type: GraphQLInt },
+    content: { type: GraphQLString },
+    channelId: { type: GraphQLInt },
+    createdAt: { type: GraphQLString },
+    updatedAt: { type: GraphQLString },
+  }),
+})
+
+export default SentenceType


### PR DESCRIPTION
This is a larger PR which creates models and migrations for `channel`, `sentence`, and `named entity` objects.  It also exposes them via a graphQL api, and uses that API for a very bare bones demo.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/208884/48221382-e8af4900-e35f-11e8-9d72-7b3305275c09.png">

Resolves #10 
Resolves #11 