### PR TITLE
Add polling to queries

### DIFF
--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -56,6 +56,7 @@ class Dashboard extends React.Component {
               after: intervalScope.startTime,
               before: intervalScope.endTime,
             }}
+            pollInterval={2000}
           >
             {({ data, error, loading }) => {
               if (loading) {
@@ -101,6 +102,7 @@ class Dashboard extends React.Component {
           <Query
             query={RECENT_SENTENCES_QUERY}
             variables={{ after: moment().subtract(5, 'minutes').toISOString() }}
+            pollInterval={2000}
           >
             {({ data, error, loading }) => {
               if (loading) {


### PR DESCRIPTION
Subscriptions are the goal, since they are likely much more efficient
and scale, but for the purposes of a demo we think that just using built
in polling functionality of ApolloClient will do the trick.

This is related to #43 and #45 in that it accomplishes the core need of simulating real time for demonstration purposes.  Ultimately I'm concerned that polling won't scale well, and that we will need to improve the backend to support apollo subscriptions.