### PR TITLE
Render entity list

### DIFF
--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -12,6 +12,8 @@ import client from '../ApolloClient'
 // Component
 class App extends React.Component {
   state = {
+    activeEntity: '',
+    highlightedEntity: '',
     intervalScope: {
       key: 'past4hours',
       startTime: moment().subtract(4, 'hours').toISOString(),
@@ -46,8 +48,16 @@ class App extends React.Component {
     this.setState({ intervalScope })
   }
 
+  setActiveEntity = (activeEntity) => {
+    this.setState({ activeEntity })
+  }
+
+  setHighlightedEntity = (highlightedEntity) => {
+    this.setState({ highlightedEntity })
+  }
+
   render() {
-    const { intervalScope } = this.state
+    const { activeEntity, highlightedEntity, intervalScope } = this.state
     return (
       <>
         <div id="mainframe">
@@ -61,6 +71,10 @@ class App extends React.Component {
                 path="/"
                 render={props => (
                   <Dashboard
+                    activeEntity={activeEntity}
+                    setActiveEntity={this.setActiveEntity}
+                    highlightedEntity={highlightedEntity}
+                    setHighlightedEntity={this.setHighlightedEntity}
                     intervalScope={intervalScope}
                     {...props}
                   />

--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -15,27 +15,34 @@ class App extends React.Component {
     intervalScope: {
       key: 'past4hours',
       startTime: moment().subtract(4, 'hours').toISOString(),
+      recentStartTime: moment().subtract(1, 'hour').toISOString(),
       endTime: moment().toISOString(),
     },
   }
 
   setIntervalScope = (key) => {
     const endTime = moment().toISOString()
-    let startTime = moment(endTime)
+    let startTime = ''
+    let recentStartTime = ''
     switch (key) {
       case 'pastweek':
-        startTime = startTime.subtract(1, 'week').toISOString()
+        startTime = moment(endTime).subtract(1, 'week').toISOString()
+        recentStartTime = moment(endTime).subtract(1, 'day').toISOString()
         break
       case 'past24hours':
-        startTime = startTime.subtract(24, 'hours').toISOString()
+        startTime = moment(endTime).subtract(24, 'hours').toISOString()
+        recentStartTime = moment(endTime).subtract(4, 'hours').toISOString()
         break
       case 'past4hours':
       default:
-        startTime = startTime.subtract(4, 'hours').toISOString()
+        startTime = moment(endTime).subtract(4, 'hours').toISOString()
+        recentStartTime = moment(endTime).subtract(1, 'hour').toISOString()
         break
     }
 
-    const intervalScope = { key, startTime, endTime }
+    const intervalScope = {
+      key, startTime, recentStartTime, endTime,
+    }
     this.setState({ intervalScope })
   }
 

--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -86,10 +86,7 @@ class Dashboard extends React.Component {
               label: key,
               total: aggregatedData[key].total,
               recent: aggregatedData[key].recent,
-            }))
-
-            // TODO: Which column we sort by will be determined by state
-            frequencyTotals.sort((a, b) => b.total - a.total)
+            })).sort((a, b) => (b.total - a.total))
 
             return (
               <>

--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -37,6 +37,8 @@ const RECENT_SENTENCES_QUERY = gql`
 `
 
 class Dashboard extends React.Component {
+  state = {}
+
   static propTypes = {
     intervalScope: PropTypes.shape({
       key: PropTypes.string,
@@ -46,8 +48,14 @@ class Dashboard extends React.Component {
     }).isRequired,
   }
 
+  setActiveEntity = (activeEntity) => {
+    this.setState({ activeEntity })
+  }
+
   render() {
     const { intervalScope } = this.props
+    const { activeEntity } = this.state
+
     return (
       <>
         <Query
@@ -93,6 +101,8 @@ class Dashboard extends React.Component {
                 <StyledEntityFrequencyTableWrapper>
                   <EntityFrequencyTable
                     data={frequencyTotals}
+                    activeEntity={activeEntity}
+                    setActiveEntity={this.setActiveEntity}
                   />
                 </StyledEntityFrequencyTableWrapper>
                 <StyledEntityFrequencyGraphWrapper>

--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -37,9 +37,11 @@ const RECENT_SENTENCES_QUERY = gql`
 `
 
 class Dashboard extends React.Component {
-  state = {}
-
   static propTypes = {
+    activeEntity: PropTypes.string.isRequired,
+    setActiveEntity: PropTypes.func.isRequired,
+    highlightedEntity: PropTypes.string.isRequired,
+    setHighlightedEntity: PropTypes.func.isRequired,
     intervalScope: PropTypes.shape({
       key: PropTypes.string,
       startTime: PropTypes.string,
@@ -48,13 +50,14 @@ class Dashboard extends React.Component {
     }).isRequired,
   }
 
-  setActiveEntity = (activeEntity) => {
-    this.setState({ activeEntity })
-  }
-
   render() {
-    const { intervalScope } = this.props
-    const { activeEntity } = this.state
+    const {
+      activeEntity,
+      setActiveEntity,
+      highlightedEntity,
+      setHighlightedEntity,
+      intervalScope,
+    } = this.props
 
     return (
       <>
@@ -102,7 +105,9 @@ class Dashboard extends React.Component {
                   <EntityFrequencyTable
                     data={frequencyTotals}
                     activeEntity={activeEntity}
-                    setActiveEntity={this.setActiveEntity}
+                    highlightedEntity={highlightedEntity}
+                    setActiveEntity={setActiveEntity}
+                    setHighlightedEntity={setHighlightedEntity}
                   />
                 </StyledEntityFrequencyTableWrapper>
                 <StyledEntityFrequencyGraphWrapper>

--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -49,24 +49,23 @@ class Dashboard extends React.Component {
     const { intervalScope } = this.props
     return (
       <>
-        <StyledEntityFrequencyTableWrapper>
-          <Query
-            query={ALL_ENTITIES_QUERY}
-            variables={{
-              after: intervalScope.startTime,
-              before: intervalScope.endTime,
-            }}
-          >
-            {({ data, error, loading }) => {
-              if (loading) {
-                return <p>Loading...</p>
-              }
-              if (error) {
-                return <p>{error.message}</p>
-              }
+        <Query
+          query={ALL_ENTITIES_QUERY}
+          variables={{
+            after: intervalScope.startTime,
+            before: intervalScope.endTime,
+          }}
+        >
+          {({ data, error, loading }) => {
+            if (loading) {
+              return <p>Loading...</p>
+            }
+            if (error) {
+              return <p>{error.message}</p>
+            }
 
-              // TODO: Aggregate this via a query instead of th'frontend
-              const aggregatedData = data.namedEntities.reduce((accumulator, currentValue) => {
+            const aggregatedData = data.namedEntities
+              .reduce((accumulator, currentValue) => {
                 if (!(currentValue.entity in accumulator)) {
                   accumulator[currentValue.entity] = 0
                 }
@@ -74,52 +73,51 @@ class Dashboard extends React.Component {
                 return accumulator
               }, {})
 
-              const frequencyTotals = Object.keys(aggregatedData).map(key => ({
-                key,
-                total: aggregatedData[key],
-              }))
+            const frequencyTotals = Object.keys(aggregatedData).map(key => ({
+              key,
+              total: aggregatedData[key],
+            }))
 
-              // TODO: Which column we sort by will be determined by state
-              frequencyTotals.sort((a, b) => b.total - a.total)
+            // TODO: Which column we sort by will be determined by state
+            frequencyTotals.sort((a, b) => b.total - a.total)
 
-              const labels = frequencyTotals.map(x => x.key)
-              const totals = frequencyTotals.map(x => x.total)
+            const labels = frequencyTotals.map(x => x.key)
+            const totals = frequencyTotals.map(x => x.total)
 
-              return (
-                <EntityFrequencyTable
-                  data={totals}
-                  labels={labels}
-                />
-              )
-            }}
-          </Query>
-        </StyledEntityFrequencyTableWrapper>
-        <StyledEntityFrequencyGraphWrapper>
-          <img alt="Graph" src={graph} width="686" height="772" />
-        </StyledEntityFrequencyGraphWrapper>
-        <StyledTranscriptAreaWrapper>
-          <Query
-            query={RECENT_SENTENCES_QUERY}
-            variables={{ after: moment().subtract(5, 'minutes').toISOString() }}
-          >
-            {({ data, error, loading }) => {
-              if (loading) {
-                return <p>Loading...</p>
-              }
-              if (error) {
-                return <p>{error.message}</p>
-              }
-
-              return (
-                <>
-                  <LiveTranscript
-                    sentences={data.sentences}
+            return (
+              <>
+                <StyledEntityFrequencyTableWrapper>
+                  <EntityFrequencyTable
+                    data={totals}
+                    labels={labels}
                   />
-                </>
-              )
-            }}
-          </Query>
-        </StyledTranscriptAreaWrapper>
+                </StyledEntityFrequencyTableWrapper>
+                <StyledEntityFrequencyGraphWrapper>
+                  <img alt="Graph" src={graph} width="686" height="772" />
+                </StyledEntityFrequencyGraphWrapper>
+              </>
+            )
+          }}
+        </Query>
+        <Query
+          query={RECENT_SENTENCES_QUERY}
+          variables={{ after: moment().subtract(5, 'minutes').toISOString() }}
+        >
+          {({ data, error, loading }) => {
+            if (loading) {
+              return <p>Loading...</p>
+            }
+            if (error) {
+              return <p>{error.message}</p>
+            }
+
+            return (
+              <StyledTranscriptAreaWrapper>
+                <LiveTranscript sentences={data.sentences} />
+              </StyledTranscriptAreaWrapper>
+            )
+          }}
+        </Query>
       </>
     )
   }

--- a/src/client/components/Dashboard.js
+++ b/src/client/components/Dashboard.js
@@ -65,6 +65,7 @@ class Dashboard extends React.Component {
             }
 
             const aggregatedData = data.namedEntities
+              .filter(namedEntity => ['PERSON', 'ORG'].includes(namedEntity.type))
               .reduce((accumulator, currentValue) => {
                 if (!(currentValue.entity in accumulator)) {
                   accumulator[currentValue.entity] = 0

--- a/src/client/components/EntityFrequency/ColumnHeader.js
+++ b/src/client/components/EntityFrequency/ColumnHeader.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+const EntityFrequencyColumnHeader = (props) => {
+  const { columnName, sortList, sorted } = props
+
+  const clickSortList = () => {
+    sortList(columnName)
+  }
+
+  return (
+    <StyledColumnHeader className={columnName} title={`Sort by ${columnName}`}>
+      <button type="button" onClick={clickSortList} data-sorted={sorted}>
+        {columnName}
+      </button>
+    </StyledColumnHeader>
+  )
+}
+EntityFrequencyColumnHeader.propTypes = {
+  columnName: PropTypes.string.isRequired,
+  sortList: PropTypes.func.isRequired,
+  sorted: PropTypes.bool.isRequired,
+}
+
+const StyledColumnHeader = styled.th`
+  padding-bottom: 0.5rem;
+
+  > button {
+    text-transform: capitalize;
+    appearance: none;
+    font-size: 1rem;
+    line-height: 1rem;
+    font-weight: 600;
+    font-family: inherit;
+    padding: 0.15rem 0;
+    margin: 0;
+    border: none;
+    border-bottom: 1px solid #2F80ED;
+    cursor: pointer;
+
+    &[data-sorted=true] {
+      border-bottom-width: 3px;
+    }
+    &:active, &:focus {
+      outline: none;
+    }
+  }
+`
+
+export default EntityFrequencyColumnHeader

--- a/src/client/components/EntityFrequency/ColumnHeader.js
+++ b/src/client/components/EntityFrequency/ColumnHeader.js
@@ -45,6 +45,7 @@ const StyledColumnHeader = styled.th`
     }
     &:active, &:focus {
       outline: none;
+      color: inherit;
     }
   }
 `

--- a/src/client/components/EntityFrequency/ColumnHeader.js
+++ b/src/client/components/EntityFrequency/ColumnHeader.js
@@ -37,6 +37,7 @@ const StyledColumnHeader = styled.th`
     margin: 0;
     border: none;
     border-bottom: 1px solid #2F80ED;
+    background-color: transparent;
     cursor: pointer;
 
     &[data-sorted=true] {

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -4,14 +4,19 @@ import { withRouter } from 'react-router-dom'
 import styled from 'styled-components'
 
 const EntityFrequencyRow = (props) => {
-  const { history, entity } = props
+  const {
+    history, entity, active, setActiveEntity,
+  } = props
 
   const selectEntity = () => {
+    setActiveEntity(entity.label)
     history.push(`/detail?entity=${entity.label}`)
   }
 
+  const setClassName = () => ((active) ? 'active' : '')
+
   return (
-    <StyledEntityFrequencyRow onClick={selectEntity}>
+    <StyledEntityFrequencyRow onClick={selectEntity} className={setClassName()}>
       <td className="label">{entity.label}</td>
       <td className="total">{entity.total}</td>
       <td className="recent">{entity.recent}</td>
@@ -19,6 +24,8 @@ const EntityFrequencyRow = (props) => {
   )
 }
 EntityFrequencyRow.propTypes = {
+  active: PropTypes.bool.isRequired,
+  setActiveEntity: PropTypes.func.isRequired,
   entity: PropTypes.shape({
     label: PropTypes.string.isRequired,
     total: PropTypes.number.isRequired,
@@ -30,6 +37,7 @@ EntityFrequencyRow.propTypes = {
 }
 
 const StyledEntityFrequencyRow = styled.tr`
+  &.active > td,
   &:hover > td {
     cursor: pointer;
     color: white;

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -31,13 +31,21 @@ const EntityFrequencyRow = (props) => {
     }
   }
 
-  const setClassName = () => {
+  const rowClassName = () => {
     const classNames = []
     if (active) {
       classNames.push('active')
     }
     if (highlighted) {
       classNames.push('highlighted')
+    }
+    return classNames.join(' ')
+  }
+
+  const recentClassName = (recent) => {
+    const classNames = ['recent']
+    if (recent === 0) {
+      classNames.push('zero')
     }
     return classNames.join(' ')
   }
@@ -49,11 +57,13 @@ const EntityFrequencyRow = (props) => {
       onBlur={unhighlightEntity}
       onMouseEnter={highlightEntity}
       onMouseLeave={unhighlightEntity}
-      className={setClassName()}
+      className={rowClassName()}
     >
       <td className="label">{entity.label}</td>
       <td className="total">{entity.total}</td>
-      <td className="recent">{entity.recent}</td>
+      <td className={recentClassName(entity.recent)}>
+        {entity.recent > 0 ? entity.recent : '–'}
+      </td>
     </StyledEntityFrequencyRow>
   )
 }
@@ -89,6 +99,10 @@ const StyledEntityFrequencyRow = styled.tr`
 
   .recent {
     background-color: #fefaee;
+  }
+
+  .zero {
+    color: lightgray;
   }
 `
 

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -9,8 +9,13 @@ const EntityFrequencyRow = (props) => {
   } = props
 
   const selectEntity = () => {
-    setActiveEntity(entity.label)
-    history.push(`/detail?entity=${entity.label}`)
+    if (active) {
+      setActiveEntity('')
+      history.push('/')
+    } else {
+      setActiveEntity(entity.label)
+      history.push(`/detail?entity=${entity.label}`)
+    }
   }
 
   const setClassName = () => ((active) ? 'active' : '')

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -5,8 +5,21 @@ import styled from 'styled-components'
 
 const EntityFrequencyRow = (props) => {
   const {
-    history, entity, active, setActiveEntity,
+    history,
+    entity,
+    active,
+    highlighted,
+    setActiveEntity,
+    setHighlightedEntity,
   } = props
+
+  const highlightEntity = () => {
+    setHighlightedEntity(entity.label)
+  }
+
+  const unhighlightEntity = () => {
+    setHighlightedEntity('')
+  }
 
   const selectEntity = () => {
     if (active) {
@@ -18,10 +31,26 @@ const EntityFrequencyRow = (props) => {
     }
   }
 
-  const setClassName = () => ((active) ? 'active' : '')
+  const setClassName = () => {
+    const classNames = []
+    if (active) {
+      classNames.push('active')
+    }
+    if (highlighted) {
+      classNames.push('highlighted')
+    }
+    return classNames.join(' ')
+  }
 
   return (
-    <StyledEntityFrequencyRow onClick={selectEntity} className={setClassName()}>
+    <StyledEntityFrequencyRow
+      onClick={selectEntity}
+      onFocus={highlightEntity}
+      onBlur={unhighlightEntity}
+      onMouseEnter={highlightEntity}
+      onMouseLeave={unhighlightEntity}
+      className={setClassName()}
+    >
       <td className="label">{entity.label}</td>
       <td className="total">{entity.total}</td>
       <td className="recent">{entity.recent}</td>
@@ -30,7 +59,9 @@ const EntityFrequencyRow = (props) => {
 }
 EntityFrequencyRow.propTypes = {
   active: PropTypes.bool.isRequired,
+  highlighted: PropTypes.bool.isRequired,
   setActiveEntity: PropTypes.func.isRequired,
+  setHighlightedEntity: PropTypes.func.isRequired,
   entity: PropTypes.shape({
     label: PropTypes.string.isRequired,
     total: PropTypes.number.isRequired,

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -4,26 +4,26 @@ import { withRouter } from 'react-router-dom'
 import styled from 'styled-components'
 
 const EntityFrequencyRow = (props) => {
-  const {
-    history, label, total, recent,
-  } = props
+  const { history, entity } = props
 
   const selectEntity = () => {
-    history.push(`/detail?entity=${label}`)
+    history.push(`/detail?entity=${entity.label}`)
   }
 
   return (
     <StyledEntityFrequencyRow onClick={selectEntity}>
-      <td className="label">{label}</td>
-      <td className="total">{total}</td>
-      <td className="recent">{recent}</td>
+      <td className="label">{entity.label}</td>
+      <td className="total">{entity.total}</td>
+      <td className="recent">{entity.recent}</td>
     </StyledEntityFrequencyRow>
   )
 }
 EntityFrequencyRow.propTypes = {
-  label: PropTypes.string.isRequired,
-  total: PropTypes.number.isRequired,
-  recent: PropTypes.number.isRequired,
+  entity: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    total: PropTypes.number.isRequired,
+    recent: PropTypes.number.isRequired,
+  }).isRequired,
   history: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,

--- a/src/client/components/EntityFrequency/Row.js
+++ b/src/client/components/EntityFrequency/Row.js
@@ -80,6 +80,13 @@ const StyledEntityFrequencyRow = styled.tr`
     background-color: #eb5757;
   }
 
+  &.active {
+    -webkit-position: sticky;
+    position: sticky;
+    top: 0;
+    bottom: 0;
+  }
+
   .recent {
     background-color: #fefaee;
   }

--- a/src/client/components/EntityFrequency/Table.js
+++ b/src/client/components/EntityFrequency/Table.js
@@ -8,12 +8,10 @@ import EntityFrequencyRow from './Row'
 class EntityFrequencyTable extends React.Component {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.object).isRequired,
-    activeEntity: PropTypes.string,
+    activeEntity: PropTypes.string.isRequired,
+    highlightedEntity: PropTypes.string.isRequired,
     setActiveEntity: PropTypes.func.isRequired,
-  }
-
-  static defaultProps = {
-    activeEntity: '',
+    setHighlightedEntity: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -92,7 +90,12 @@ class EntityFrequencyTable extends React.Component {
   }
 
   render() {
-    const { activeEntity, setActiveEntity } = this.props
+    const {
+      activeEntity,
+      setActiveEntity,
+      highlightedEntity,
+      setHighlightedEntity,
+    } = this.props
     const { data, sortBy } = this.state
 
     return (
@@ -110,7 +113,9 @@ class EntityFrequencyTable extends React.Component {
               entity={entity}
               key={(entity.label + Math.round(Math.random() * 10000))}
               active={entity.label === activeEntity}
+              highlighted={entity.label === highlightedEntity}
               setActiveEntity={setActiveEntity}
+              setHighlightedEntity={setHighlightedEntity}
             />
           ))}
         </tbody>

--- a/src/client/components/EntityFrequency/Table.js
+++ b/src/client/components/EntityFrequency/Table.js
@@ -6,8 +6,7 @@ import EntityFrequencyRow from './Row'
 
 class EntityFrequencyTable extends React.Component {
   static propTypes = {
-    data: PropTypes.arrayOf(PropTypes.number).isRequired,
-    labels: PropTypes.arrayOf(PropTypes.string).isRequired,
+    data: PropTypes.arrayOf(PropTypes.object).isRequired,
   }
 
   componentDidMount() {
@@ -30,18 +29,16 @@ class EntityFrequencyTable extends React.Component {
   }
 
   render() {
-    const { data, labels } = this.props
+    const { data } = this.props
 
     const sortList = (e) => {
       e.preventDefault()
     }
 
-    const renderedEntities = data.map((d, i) => (
+    const renderedEntities = data.map(entity => (
       <EntityFrequencyRow
-        label={labels[i]}
-        total={d}
-        recent={Math.round(d * Math.random())}
-        key={(labels[i] + Math.round(Math.random() * 10000))}
+        entity={entity}
+        key={(entity.label + Math.round(Math.random() * 10000))}
       />
     ))
 

--- a/src/client/components/EntityFrequency/Table.js
+++ b/src/client/components/EntityFrequency/Table.js
@@ -8,6 +8,12 @@ import EntityFrequencyRow from './Row'
 class EntityFrequencyTable extends React.Component {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.object).isRequired,
+    activeEntity: PropTypes.string,
+    setActiveEntity: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    activeEntity: '',
   }
 
   constructor(props) {
@@ -86,6 +92,7 @@ class EntityFrequencyTable extends React.Component {
   }
 
   render() {
+    const { activeEntity, setActiveEntity } = this.props
     const { data, sortBy } = this.state
 
     return (
@@ -102,6 +109,8 @@ class EntityFrequencyTable extends React.Component {
             <EntityFrequencyRow
               entity={entity}
               key={(entity.label + Math.round(Math.random() * 10000))}
+              active={entity.label === activeEntity}
+              setActiveEntity={setActiveEntity}
             />
           ))}
         </tbody>


### PR DESCRIPTION
We now render the entity list according to the interval specified; allow scrolling of long lists (while keeping the column headers fixed); style each row while hovering on it (and broadcast to the App state that the row is being hovered, for later corresponding to graph lines and other instances of the entity around the app); style each row when it's clicked/selected (and again broadcast that); update the URL when selecting an entity; lock the selected entity to the top/bottom of the list when scrolling out of view; and allow sorting (and reverse sorting) of each column by clicking the column header.

![32-rendered-entity-list](https://user-images.githubusercontent.com/4731/54639297-094c8580-4a5b-11e9-824e-d57c420dfa77.gif)

There are some lingering issues that predate this task, such as why all state changes (like setting the active or highlighted entity) cause a new query to be run and thus a full-page re-render, but we'll address those separately.

Closes #32 
