### PR TITLE
Store sentence IDs in the correct named entity field

### DIFF
--- a/src/server/workers/openedCaptions/index.js
+++ b/src/server/workers/openedCaptions/index.js
@@ -81,7 +81,7 @@ async function processSentence(content) {
   ents.map(ent => models.NamedEntity.create({
     entity: sentence.substring(ent.start, ent.end),
     type: ent.label,
-    sentenceId: storedSentence.id,
+    sentence_id: storedSentence.id,
     model: 'en_core_web_lg',
   }))
 }


### PR DESCRIPTION
Prior to this change, when named entities were created, their appearing sentence wasn’t being associated because we were trying to store its ID in `sentenceId` instead of `sentence_id`, the latter of which is the actual Postgres column name.

![49-null-sentence-id](https://user-images.githubusercontent.com/4731/55155219-30771700-512d-11e9-8b95-69911a122be7.gif)

However, by explicitly snake-casing at this point, we may be breaking some of the correct stitching of snake-cased Postgres fields to camelCased object attributes, and so we need to debug whether this is all associated together correctly by Sequelize and queryable by GraphQL.

Closes #49